### PR TITLE
Fixed `event?eventId=[id]` not redirecting deleted events.

### DIFF
--- a/.github/workflows/prettify_code.yml
+++ b/.github/workflows/prettify_code.yml
@@ -11,7 +11,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.3
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
         with:
-          prettier_options: --write .
+          node-version: "18.17.0"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prettify code
+        run: npm run format

--- a/app/event/page.tsx
+++ b/app/event/page.tsx
@@ -1,15 +1,14 @@
 import { redirect } from "next/navigation";
 
-import { getEvent } from "./getEvent";
-
 export default async function EventPage(req: any, res: any) {
-  const { eventId } = req.searchParams;
+  // Check if can be redirected to a specific event on the `event/[id]` path.
+  const specificEvent =
+    Object.keys(req.searchParams).length === 1 &&
+    req.searchParams.eventId !== undefined;
 
-  if (!eventId) {
-    redirect("/");
+  if (specificEvent) {
+    redirect(`event/${req.searchParams.eventId}`);
+  } else {
+    redirect(`/`);
   }
-
-  const event = await getEvent({ eventId: eventId });
-
-  redirect(event.getPath());
 }


### PR DESCRIPTION
- Fixed bug, now redirects to homepage where the `/event` path is called without the correct search parameters and to the event if only the `eventId` search parameter is passed.
- Removed usage of google api when calling this route, should decrease some small amount of our usage.

close #90 